### PR TITLE
clarity renames

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -430,7 +430,7 @@ namespace AstroModLoader
             }
 
             TextPrompt getIPPrompt = new TextPrompt();
-            getIPPrompt.DisplayText = "Enter an IP to sync with:";
+            getIPPrompt.DisplayText = "Enter an IP:Port to sync with:";
             getIPPrompt.Width -= 100;
             getIPPrompt.AllowBrowse = false;
             getIPPrompt.StartPosition = FormStartPosition.Manual;

--- a/ProfileSelector.Designer.cs
+++ b/ProfileSelector.Designer.cs
@@ -141,7 +141,7 @@
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(65, 26);
             this.cancelButton.TabIndex = 3;
-            this.cancelButton.Text = "Exit";
+            this.cancelButton.Text = "Close";
             this.cancelButton.UseVisualStyleBackColor = false;
             this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
             // 

--- a/SettingsForm.Designer.cs
+++ b/SettingsForm.Designer.cs
@@ -105,7 +105,7 @@
             this.exitButton.Name = "exitButton";
             this.exitButton.Size = new System.Drawing.Size(75, 26);
             this.exitButton.TabIndex = 8;
-            this.exitButton.Text = "Exit";
+            this.exitButton.Text = "Close";
             this.exitButton.UseVisualStyleBackColor = false;
             this.exitButton.Click += new System.EventHandler(this.exitButton_Click);
             // 


### PR DESCRIPTION
Changed the "Exit" text in two forms to "Close". This is to avoid someone thinking that button closes the entire application. Also added Port to text for snyc.